### PR TITLE
show_special_characters

### DIFF
--- a/src/components/NostrEventsTable.tsx
+++ b/src/components/NostrEventsTable.tsx
@@ -509,22 +509,7 @@ const NostrEventsTable: React.FC = () => {
       dataIndex: 'paymentMethods',
       key: 'paymentMethods',
       render: (methods: string | null) => {
-        if (!methods) return '-';
-
-        // Check for characters that are likely emojis using a simple for loop
-        // Most emojis have character codes > 127 (outside standard ASCII)
-        let hasEmoji = false;
-        for (let i = 0; i < methods.length; i++) {
-          if (methods.charCodeAt(i) > 127) {
-            hasEmoji = true;
-            break;
-          }
-        }
-
-        // If it contains emoji, display just a dash
-        if (hasEmoji) return '-';
-
-        return <div>{methods}</div>;
+        return methods || '-';
       },
     },
 

--- a/src/components/NostrEventsTable.tsx
+++ b/src/components/NostrEventsTable.tsx
@@ -509,7 +509,25 @@ const NostrEventsTable: React.FC = () => {
       dataIndex: 'paymentMethods',
       key: 'paymentMethods',
       render: (methods: string | null) => {
-        return methods || '-';
+        if (!methods) return '-';
+        
+        const removeDecorations = (str: string): string =>
+          str.replace(
+            /[\p{Emoji_Presentation}\p{Extended_Pictographic}\p{Symbol}\p{Other_Symbol}\u200d\uFE0F\u3000-\u303F]/gu,
+            ''
+          );
+
+        const cleanText = removeDecorations(methods).replace(/\s+/g, ' ').trim();
+        
+        if (!cleanText) return '-';
+    
+        const shortText = cleanText.length > 40 ? `${cleanText.slice(0, 40)}…` : cleanText;
+    
+        return (
+          <Tooltip title={methods}>
+            <div>{shortText}</div>
+          </Tooltip>
+        );
       },
     },
 


### PR DESCRIPTION
A large portion of @lnp2pbot orders are created by Spanish-speaking users, and their payment methods often include special characters like `ñ` or accented vowels. However, currently, if the `pm` tag contains such characters, the "Payment Methods" column displays a dash (-) instead, which can confuse users and prevent them from taking an order if they can’t see what the actual payment method is.

Additionally, many users include emojis in their payment methods, such as country flags or icons to stylize their offers. These are also currently replaced with a dash.

This PR removes that restriction, ensuring that special characters and emojis in the `pm` tag are displayed correctly.