### PR TITLE
Add MLC and IRT flags

### DIFF
--- a/src/components/NostrEventsTable.tsx
+++ b/src/components/NostrEventsTable.tsx
@@ -74,6 +74,8 @@ const getCurrencyFlag = (currencyCode: string | null): string => {
       ZAR: '🇿🇦', // South African Rand
       VES: '🇻🇪', // Venezuelan Bolívar Soberano
       USDVE: '🇻🇪', // USD in Venezuela (custom code)
+      MLC: '🇨🇺', // Moneda Libremente Convertible (Cuba)
+      IRT: '🇮🇷', // Iranian Rial Toman
       BTC: '₿', // Bitcoin with its symbol instead of a flag
     };
 


### PR DESCRIPTION
Currently missing currency flags for MLC (Cuba) and IRT (Iran). This small PR adds them since they're not included in the iso-country-currency library.