### PR TITLE
filter out inactive HodlHodl offers using their public API

### DIFF
--- a/src/components/NostrEventsTable.tsx
+++ b/src/components/NostrEventsTable.tsx
@@ -170,6 +170,29 @@ const NostrEventsTable: React.FC = () => {
     setCurrentPage(page);
   };
 
+  // Returns a comparator function for the given sorter, or null if no sort is active
+  const getSortFunction = (
+    sorter: SorterResult<SorterInfo>
+  ): ((a: EventTableData, b: EventTableData) => number) | null => {
+    if (!sorter.columnKey || !sorter.order) return null;
+    return (a: EventTableData, b: EventTableData) => {
+      if (sorter.columnKey === 'premium') {
+        const premiumA = a.premium ? parseFloat(a.premium) : 0;
+        const premiumB = b.premium ? parseFloat(b.premium) : 0;
+        return sorter.order === 'ascend' ? premiumA - premiumB : premiumB - premiumA;
+      } else if (sorter.columnKey === 'bond') {
+        const bondA = a.bond ? parseFloat(a.bond) : 0;
+        const bondB = b.bond ? parseFloat(b.bond) : 0;
+        return sorter.order === 'ascend' ? bondA - bondB : bondB - bondA;
+      } else if (sorter.columnKey === 'created_at') {
+        return sorter.order === 'ascend'
+          ? a.created_at - b.created_at
+          : b.created_at - a.created_at;
+      }
+      return 0;
+    };
+  };
+
   // Handle table change for sorting
   const handleTableChange = (
     _pagination: TablePaginationConfig,
@@ -179,32 +202,11 @@ const NostrEventsTable: React.FC = () => {
     setSortedInfo(sorter);
 
     if (sorter && sorter.columnKey) {
-      // Create sorting function based on the column that was clicked
-      const sortFunction = (a: EventTableData, b: EventTableData) => {
-        if (sorter.columnKey === 'premium') {
-          const premiumA = a.premium ? parseFloat(a.premium) : 0;
-          const premiumB = b.premium ? parseFloat(b.premium) : 0;
-          return sorter.order === 'ascend' ? premiumA - premiumB : premiumB - premiumA;
-        } else if (sorter.columnKey === 'bond') {
-          const bondA = a.bond ? parseFloat(a.bond) : 0;
-          const bondB = b.bond ? parseFloat(b.bond) : 0;
-          return sorter.order === 'ascend' ? bondA - bondB : bondB - bondA;
-        } else if (sorter.columnKey === 'created_at') {
-          // Default sorting by timestamp (newest first or oldest first)
-          return sorter.order === 'ascend'
-            ? a.created_at - b.created_at
-            : b.created_at - a.created_at;
-        }
-        return 0;
-      };
-
-      // Sort both the original and filtered events
-      const sortedEvents = [...tableEvents].sort(sortFunction);
-      const sortedFilteredEvents = [...filteredEvents].sort(sortFunction);
-
-      // Update both state variables
-      setTableEvents(sortedEvents);
-      setFilteredEvents(sortedFilteredEvents);
+      const sortFn = getSortFunction(sorter);
+      if (sortFn) {
+        setTableEvents(prev => [...prev].sort(sortFn));
+        setFilteredEvents(prev => [...prev].sort(sortFn));
+      }
     }
   };
 
@@ -365,6 +367,10 @@ const NostrEventsTable: React.FC = () => {
         return match ? hodlHodlValidIds.has(match[1]) : true;
       });
     }
+
+    // Re-apply active sort so incoming events don't disrupt the user's chosen order
+    const sortFn = getSortFunction(sortedInfo);
+    if (sortFn) result = [...result].sort(sortFn);
 
     setFilteredEvents(result);
     setTotalEvents(result.length);

--- a/src/components/NostrEventsTable.tsx
+++ b/src/components/NostrEventsTable.tsx
@@ -18,7 +18,7 @@ import cypherpunkQuotes from '../data/cypherpunkQuotes.json';
 import { ExportOutlined } from '@ant-design/icons';
 import OnionAddressWarning from './OnionAddressWarning';
 import * as isoCountryCurrency from 'iso-country-currency';
-import { processEvent, updateExchangeRates } from 'functions';
+import { processEvent, updateExchangeRates, fetchValidHodlHodlOfferIds } from 'functions';
 import { allowedPubkeys, useNostrEvents } from 'context/NostrEventsContext';
 import DepthChart from './DepthChart';
 import { FilterValue, SorterResult } from 'antd/es/table/interface';
@@ -124,6 +124,7 @@ const NostrEventsTable: React.FC = () => {
   const [ratesLoading, setRatesLoading] = useState<boolean>(true);
   const [rateSources, setRateSources] = useState<string[]>([]);
   const [sortedInfo, setSortedInfo] = useState<SorterResult<SorterInfo>>({});
+  const [hodlHodlValidIds, setHodlHodlValidIds] = useState<Set<string> | null>(null);
 
   // Filter states
   const [sourceFilter, setSourceFilter] = useState<string | null>(null);
@@ -356,6 +357,15 @@ const NostrEventsTable: React.FC = () => {
       );
     }
 
+    // Filter out HodlHodl offers that are no longer active
+    if (hodlHodlValidIds !== null) {
+      result = result.filter(event => {
+        if (event.source !== 'hodlhodl') return true;
+        const match = event.link.match(/hodlhodl\.com\/offers\/([^?/]+)/);
+        return match ? hodlHodlValidIds.has(match[1]) : true;
+      });
+    }
+
     setFilteredEvents(result);
     setTotalEvents(result.length);
   };
@@ -363,6 +373,11 @@ const NostrEventsTable: React.FC = () => {
   // Main effect to coordinate data loading
   useEffect(() => {
     loadData();
+  }, []);
+
+  // Fetch valid HodlHodl offer IDs in background to filter out inactive offers
+  useEffect(() => {
+    fetchValidHodlHodlOfferIds().then(setHodlHodlValidIds);
   }, []);
 
   // Effect to update prices when exchange rates change
@@ -387,7 +402,7 @@ const NostrEventsTable: React.FC = () => {
   // Effect to filter events when filter states or events change
   useEffect(() => {
     calculateFilteredevents(tableEvents);
-  }, [sourceFilter, typeFilter, currencyFilter, paymentMethodFilter, webOfTrust]);
+  }, [sourceFilter, typeFilter, currencyFilter, paymentMethodFilter, webOfTrust, hodlHodlValidIds]);
 
   // Calculate current page data from filtered events
   const startIndex = (currentPage - 1) * pageSize;

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -230,6 +230,33 @@ export const calculateBtcPrice = (
   }
 };
 
+export const fetchValidHodlHodlOfferIds = async (): Promise<Set<string>> => {
+  const validIds = new Set<string>();
+  const limit = 100;
+  let offset = 0;
+
+  try {
+    while (true) {
+      const response = await fetch(
+        `https://hodlhodl.com/api/v1/offers?filters%5Basset_code%5D=BTC&pagination%5Blimit%5D=${limit}&pagination%5Boffset%5D=${offset}`
+      );
+      if (!response.ok) break;
+
+      const data = await response.json();
+      if (!data.offers || data.offers.length === 0) break;
+
+      data.offers.forEach((offer: { id: string }) => validIds.add(offer.id));
+
+      if (data.offers.length < limit) break;
+      offset += limit;
+    }
+  } catch (error) {
+    console.error('Error fetching HodlHodl active offers:', error);
+  }
+
+  return validIds;
+};
+
 export const updateExchangeRates: () => Promise<[Record<string, number>, string[]]> = async () => {
   console.log('Fetching exchange rates from multiple sources...');
 


### PR DESCRIPTION
## Problem

  Some HodlHodl offer links shown in the table are broken. HodlHodl
  publishes Nostr events when offers are created, but when an offer is
  taken or cancelled, the Nostr event is not always removed. As a result,
  the app displays offers that no longer exist on HodlHodl, leading to
  broken links.

  ## Fix

  On load, the app fetches all currently active HodlHodl offer IDs from
  their public API (`/api/v1/offers`), paginating through results (100 per
  page) until all active IDs are collected. These are stored in a Set for
  O(1) lookup.

  Before rendering, any HodlHodl event whose offer ID is not in that Set
  is filtered out. Offers from other sources (RoboSats, Peach, etc.) are
  unaffected.

  The fetch runs in the background — the table renders immediately with
  Nostr data, and inactive HodlHodl offers disappear automatically once
  the API response arrives (~1–2 seconds), with no user action required.